### PR TITLE
Fix tok_io compilation error: do_control return type must be void

### DIFF
--- a/unproto/tok_io.c
+++ b/unproto/tok_io.c
@@ -189,7 +189,7 @@ static char *ignore_directives[] = {
 
 /* do_control - parse control line */
 
-static int do_control()
+static void do_control()
 {
     struct token *t;
     int     line;


### PR DESCRIPTION
This change permits to compile dev86 on macOS Sierra, otherwise the compilation stops with error. I'm using:

```
Apple LLVM version 8.0.0 (clang-800.0.38)
Target: x86_64-apple-darwin16.0.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

I don't know which other compiler stops with error in the same case.
